### PR TITLE
fix(v0-core): assign pendingRedeemRequest correctly in User constructor

### DIFF
--- a/packages/v0-core/package.json
+++ b/packages/v0-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-core",
   "description": "Framework-agnostic package that defines Lagoon related entity classes (such as Vault)",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/src/vault/User.ts
+++ b/packages/v0-core/src/vault/User.ts
@@ -160,7 +160,7 @@ export class User {
     this.balanceInAssets = balanceInAssets;
 
     this.pendingRedeemRequestInAssets = pendingRedeemRequestInAssets;
-    this.pendingRedeemRequest = pendingDepositRequest
+    this.pendingRedeemRequest = pendingRedeemRequest;
     this.maxWithdraw = maxWithdraw;
     this.maxRedeem = maxRedeem;
     

--- a/packages/v0-core/test/User.test.ts
+++ b/packages/v0-core/test/User.test.ts
@@ -1,0 +1,60 @@
+import { test, describe, expect } from "bun:test";
+import { User } from "../src/vault/User";
+
+const address = "0x1111111111111111111111111111111111111111";
+const vault = "0x2222222222222222222222222222222222222222";
+
+describe("User", () => {
+  test("constructor assigns pendingRedeemRequest from the pendingRedeemRequest argument (not pendingDepositRequest)", () => {
+    const pendingDepositRequest = 100n;
+    const pendingRedeemRequest = 42n;
+
+    const user = new User({
+      address,
+      vault,
+      hasDepositRequestOnboarded: false,
+      hasRedeemRequestOnboarded: false,
+      lastDepositRequestId: 0,
+      lastRedeemRequestId: 0,
+      pendingDepositRequest,
+      pendingDepositRequestInShares: 0n,
+      maxMint: 0n,
+      maxDeposit: 0n,
+      claimableDepositRequestActualized: 0n,
+      balance: 0n,
+      balanceInAssets: 0n,
+      pendingRedeemRequest,
+      pendingRedeemRequestInAssets: 0n,
+      maxWithdraw: 0n,
+      maxRedeem: 0n,
+    });
+
+    expect(user.pendingRedeemRequest).toBe(pendingRedeemRequest);
+    expect(user.pendingDepositRequest).toBe(pendingDepositRequest);
+  });
+
+  test("positionInShares uses pendingRedeemRequest parameter", () => {
+    const user = new User({
+      address,
+      vault,
+      hasDepositRequestOnboarded: false,
+      hasRedeemRequestOnboarded: false,
+      lastDepositRequestId: 0,
+      lastRedeemRequestId: 0,
+      pendingDepositRequest: 100n,
+      pendingDepositRequestInShares: 10n,
+      maxMint: 20n,
+      maxDeposit: 0n,
+      claimableDepositRequestActualized: 0n,
+      balance: 30n,
+      balanceInAssets: 0n,
+      pendingRedeemRequest: 40n,
+      pendingRedeemRequestInAssets: 0n,
+      maxWithdraw: 0n,
+      maxRedeem: 50n,
+    });
+
+    // 10 + 20 + 30 + 40 + 50 = 150
+    expect(user.positionInShares).toBe(150n);
+  });
+});


### PR DESCRIPTION
## Bug

In `packages/v0-core/src/vault/User.ts:163`, the `User` constructor was assigning the wrong parameter:

```ts
this.pendingRedeemRequest = pendingDepositRequest
```

The RHS should be `pendingRedeemRequest`, not `pendingDepositRequest`.

## Impact

`user.pendingRedeemRequest` always returned the pending deposit value. Any SDK consumer reading that property directly gets incorrect data. The bug is also present in the published build shipped via `@lagoon-protocol/v0-viem`.

Note: the local `pendingRedeemRequest` parameter is still used correctly in the `positionInShares` computation below, so that derived value is unaffected — only direct reads of the property were wrong.

## How it was found

Downstream backend (`lagoon-backend`) investigation while adding GraphQL fields for user position state.

## Fix

```ts
this.pendingRedeemRequest = pendingRedeemRequest;
```

Also bumps `@lagoon-protocol/v0-core` from `0.19.0` → `0.19.1` (patch).

## Test plan

- Added `packages/v0-core/test/User.test.ts` with:
  - a test that constructs a `User` with distinct `pendingDepositRequest` (100n) and `pendingRedeemRequest` (42n) values and asserts `user.pendingRedeemRequest === 42n` and `user.pendingDepositRequest === 100n` — this would have caught the bug.
  - a test verifying `positionInShares` still uses the `pendingRedeemRequest` parameter correctly.
- `cd packages/v0-core && bun test` — 18 pass, 0 fail.
- `bun run build` — all three packages build cleanly.