### PR TITLE
fix(peers): set v0-core peer to ^0.19.0 in v0-viem and v0-computation

### DIFF
--- a/packages/v0-computation/package.json
+++ b/packages/v0-computation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-computation",
   "description": "Computation package that defines some Lagoon related computations utilities",
-  "version": "0.15.5",
+  "version": "0.16.0",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",
@@ -38,7 +38,7 @@
     "vitest": "^3.2.3"
   },
   "peerDependencies": {
-    "@lagoon-protocol/v0-core": "workspace:*",
+    "@lagoon-protocol/v0-core": "^0.19.0",
     "viem": "^2.0.0"
   },
   "private": false,

--- a/packages/v0-viem/package.json
+++ b/packages/v0-viem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-viem",
   "description": "Viem based package that defines Lagoon utilities for vault core classes",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",
@@ -38,7 +38,7 @@
     "vitest": "^3.2.3"
   },
   "peerDependencies": {
-    "@lagoon-protocol/v0-core": "workspace:*",
+    "@lagoon-protocol/v0-core": "^0.19.0",
     "viem": "^2.0.0"
   },
   "private": false,


### PR DESCRIPTION
## Summary

- Replace `"workspace:*"` in the v0-core peer of **v0-viem** and **v0-computation** with `"^0.19.0"`.
- Minor bumps (peer range change is breaking for consumers):
  - v0-viem: **0.17.2 → 0.18.0**
  - v0-computation: **0.15.5 → 0.16.0**

## Why

`bun publish` rewrites `workspace:*` to the exact v0-core version present at publish time. Currently published releases ship a literal exact pin:

```
$ npm view @lagoon-protocol/v0-viem@0.17.2 peerDependencies
{ '@lagoon-protocol/v0-core': '0.18.0', viem: '^2.0.0' }
```

Any consumer declaring `"@lagoon-protocol/v0-core": "^0.19.x"` triggers a peer warning **and** bun resolves a separate `v0-core@0.18.0` copy nested under `node_modules/@lagoon-protocol/v0-viem/node_modules/` to satisfy the peer. Two physical copies of v0-core in a single install = two distinct class identities → `event instanceof FeeTaken` returns false across SDK boundaries.

## Compatibility verified

Tests run locally against v0-core@0.19.3 (current workspace version):

| Package | Suite | Result |
|---|---|---|
| v0-core | `bun test` (3 files) | 18/18 ✅ |
| v0-viem | vitest + mainnet/arbitrum forks (2 files) | 54/54 ✅ |
| v0-computation | vitest (3 files) | 21/21 ✅ |

`^0.19.0` honestly reflects what has been tested. Under 0.x semver that means `>=0.19.0 <0.20.0` — when v0-core cuts 0.20.0, v0-viem and v0-computation will need a new release with an updated peer (standard coordinated-release discipline).

## Consumer impact

After this ships, `infrastructure` repo can:
- Bump `apps/smeltery/package.json` to `"@lagoon-protocol/v0-viem": "^0.18.0"`
- Delete the `overrides` block from root `package.json` (the duplicate-install workaround is no longer needed)
- `bun install` should show a single v0-core copy under `node_modules/@lagoon-protocol/`

## Test plan

- [x] `bun install` — workspace resolves cleanly
- [x] `bun run build` — all three packages build (types + cjs + esm)
- [x] v0-core tests pass at 0.19.3
- [x] v0-viem tests pass at 0.19.3 (54/54 mainnet + arbitrum fork tests)
- [x] v0-computation tests pass at 0.19.3
- [ ] After merge: publish both packages; verify `npm view @lagoon-protocol/v0-viem@0.18.0 peerDependencies` shows `"^0.19.0"` literal (not an exact pin)
- [ ] In infrastructure: bump v0-viem to ^0.18.0, drop the v0-core override, confirm single v0-core copy under `node_modules/`