### PR TITLE
fix(v0-computation): guard zero price-per-share in simulate/computeAPR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,24 @@ All new fields except `upcomingFeeRates` are optional and default to zero/false.
   });
 ```
 
+### `computeAPR` return type widened to `number | undefined`
+
+`computeAPR` now returns `undefined` when `oldPrice === 0n` (no baseline price → APR is undefined for the period). Previously it threw `RangeError: Division by zero`.
+
+```diff
+- function computeAPR(...): number
++ function computeAPR(...): number | undefined
+```
+
+`SimulationResult.periodNetApr` widened the same way (it was already `number`; now `number | undefined`, matching `periodGrossApr`).
+
+Consumer code that does `apr.toFixed(2)` or assigns to `number` must handle the undefined case:
+
+```diff
+- aprValue: result.periodNetApr.toFixed(2)
++ aprValue: result.periodNetApr?.toFixed(2) ?? '0.00'
+```
+
 ---
 
 ## New Features
@@ -154,6 +172,12 @@ All are automatically called by `fetchVault()`.
 ### Management fee calculation updated for v0.6.0
 
 v0.6.0 uses the **average** of current and proposed total assets for management fee computation, matching the updated contract logic.
+
+### `simulate()` no longer throws on pre-first-valuation vaults
+
+Vaults with shares minted but `totalAssets = 0` (e.g. between initialization and first NAV proposal) caused `convertToAssets()` to round `currentPricePerShare` to `0n`. `simulate()` then called `computeAPR()` and threw `RangeError: Division by zero`, breaking the manage page exactly when curators tried to propose the first valuation.
+
+`simulate()` now returns successfully in this state with `periodNetApr`, `periodGrossApr`, `thirtyDaysNetApr`, and `inceptionNetApr` set to `undefined` whenever the corresponding baseline price is `0n`.
 
 ---
 

--- a/packages/v0-computation/src/APR.ts
+++ b/packages/v0-computation/src/APR.ts
@@ -17,9 +17,9 @@ export function computeAPR({
   oldPrice: bigint;
   newTimestamp: bigint;
   oldTimestamp: bigint;
-}): number {
-  if (oldPrice < 0 || newPrice < 0) {
-    throw new Error("Prices must be greater than zero.");
+}): number | undefined {
+  if (oldPrice < 0n || newPrice < 0n) {
+    throw new Error("Prices must be non-negative.");
   }
   if (oldTimestamp > newTimestamp) {
     throw new Error("oldestTimestamp must be less than newestTimestamp.");
@@ -27,6 +27,9 @@ export function computeAPR({
   const periodSeconds = newTimestamp - oldTimestamp;
 
   if (periodSeconds === 0n) return 0;
+  // No baseline price (e.g. pre-first-valuation: shares minted but totalAssets = 0):
+  // APR is undefined for the period — let the caller decide how to display it.
+  if (oldPrice === 0n) return undefined;
 
   const gain = newPrice - oldPrice;
   const decimals = 18;

--- a/packages/v0-computation/src/simulation/simulation.ts
+++ b/packages/v0-computation/src/simulation/simulation.ts
@@ -62,6 +62,8 @@ export function simulate(
   const highWaterMark = MathLib.max(vault.highWaterMark, netPricePerShare);
 
   // We have everything to evaluate the past performance and can now compute the APRs.
+  // computeAPR returns undefined when the baseline price is 0n (e.g. pre-first-valuation:
+  // shares minted but totalAssets = 0) — callers should treat that as "APR not applicable".
   const periodNetApr = computeAPR({
     newPrice: netPricePerShare,
     oldPrice: currentPricePerShare,
@@ -69,19 +71,15 @@ export function simulate(
     oldTimestamp: vault.lastFeeTime,
   });
 
-
-  const periodGrossApr = currentPricePerShare > 0n ? computeAPR({
+  const periodGrossApr = computeAPR({
     newPrice: grossPricePerShare,
     oldPrice: currentPricePerShare,
     newTimestamp: now,
     oldTimestamp: vault.lastFeeTime,
-  }) : undefined;
+  });
 
-  let thirtyDaysNetApr = undefined;
+  let thirtyDaysNetApr: number | undefined = undefined;
   if (input.thirtyDay) {
-    if (input.thirtyDay.pricePerShare == 0n) 
-      throw new Error("Thirty day price per share must be greater than 0");
-
     thirtyDaysNetApr = computeAPR({
       newPrice: netPricePerShare,
       oldPrice: input.thirtyDay.pricePerShare,
@@ -90,11 +88,8 @@ export function simulate(
     });
   }
 
-  let inceptionNetApr = undefined;
+  let inceptionNetApr: number | undefined = undefined;
   if (input.inception) {
-    if (input.inception.pricePerShare == 0n) 
-      throw new Error("Inception price per share must be greater than 0");
-
     inceptionNetApr = computeAPR({
       newPrice: netPricePerShare,
       oldPrice: input.inception.pricePerShare,

--- a/packages/v0-computation/src/types.ts
+++ b/packages/v0-computation/src/types.ts
@@ -68,7 +68,7 @@ export interface SimulationResult {
     inShares: bigint;
   };
   excessReturns: bigint;
-  periodNetApr: number;
+  periodNetApr?: number;
   periodGrossApr?: number;
   thirtyDaysNetApr?: number;
   inceptionNetApr?: number;

--- a/packages/v0-computation/test/simulation.test.ts
+++ b/packages/v0-computation/test/simulation.test.ts
@@ -116,3 +116,36 @@ test("simulation should compute exit fees when exitRate > 0", () => {
     expect(result.entryFees.inShares).toBe(0n);
     expect(result.entryFees.inAssets).toBe(0n);
 });
+
+// Pre-first-valuation: shares minted but totalAssets = 0 → currentPricePerShare rounds to 0n.
+// simulate() must not throw "Division by zero" and APRs must be undefined for that period.
+test("simulation should not throw when currentPricePerShare is 0n", () => {
+    const simulationInput: SimulationInput = {
+      totalAssetsForSimulation: 260_000_000_511_285n, // ~260M USDC (6 decimals)
+      assetsInSafe: 0n,
+      pendingSiloBalances: { assets: 0n, shares: 0n },
+      pendingSettlement: { assets: 0n, shares: 0n },
+      settleDeposit: true,
+      inception: { timestamp: 1765267664, pricePerShare: 0n },
+      thirtyDay: { timestamp: 1765267664, pricePerShare: 0n },
+    };
+
+    const vault = {
+      decimals: 18,
+      underlyingDecimals: 6,
+      newTotalAssets: 2n ** 256n - 1n, // canSettle = false (MAX_UINT_256)
+      totalAssets: 0n,
+      totalSupply: 26_511_259_000_000_000_000n, // ~26.5 shares minted, no NAV yet
+      highWaterMark: 0n,
+      lastFeeTime: BigInt(Math.floor(Date.now() / 1000)) - 3600n,
+      feeRates: { managementRate: 0, performanceRate: 0, entryRate: 0, exitRate: 0 },
+      version: Version.v0_6_0,
+    };
+
+    const result = simulate(vault, simulationInput);
+
+    expect(result.periodNetApr).toBeUndefined();
+    expect(result.periodGrossApr).toBeUndefined();
+    expect(result.thirtyDaysNetApr).toBeUndefined();
+    expect(result.inceptionNetApr).toBeUndefined();
+});


### PR DESCRIPTION
## Summary

Pre-first-valuation vaults (shares minted, `totalAssets = 0`) crash `simulate()` with `RangeError: Division by zero`. Reproduced on Hemi USDC ([pprod link](https://pprod.lagoon.finance/manage/43111/0xe9c300b75d0998f46446cab7997b4646d7cc33f8?nav=260000000.511285)) — the manage page errors out exactly when the curator tries to propose the first NAV.

### Root cause

With virtual-offset accounting:

```
PPS = oneShare * (totalAssets + 1) / (totalSupply + 10^decimalsOffset)
```

For Hemi USDC: `1e18 * 1 / (2.65e19 + 1e12)` rounds down to `0n`. Then `simulate()` calls `computeAPR({ oldPrice: 0n, ... })` and the division `periodYield / (periodSeconds * oldPrice)` throws.

### Fix

- **`APR.ts`** — return `undefined` when `oldPrice === 0n` (APR is undefined for the period; let the caller decide how to display it). Tighten the non-negativity check (`< 0` → `< 0n`) and rename the error message to "Prices must be non-negative."
- **`simulation.ts`** — drop the now-redundant outer guards on `currentPricePerShare > 0n` and `pricePerShare > 0n`. `computeAPR`'s return type is the single source of truth for the "no baseline" case.
- **`types.ts`** — `periodNetApr` is now optional, matching `periodGrossApr`.

### Test

New vitest case in `simulation.test.ts` reproducing the Hemi USDC state (`totalAssets = 0n`, `totalSupply = 26.5e18`) and asserting `simulate()` returns with all four APRs `undefined`.

## :warning: Release note — bump as **minor**, not patch

This widens public types and is a breaking change for TypeScript consumers:

```diff
- function computeAPR(...): number
+ function computeAPR(...): number | undefined

  interface SimulationResult {
-   periodNetApr: number
+   periodNetApr?: number
    ...
  }
```

Consumer code that does `apr.toFixed(2)` or assigns to `number` will fail to compile (and untyped JS will hit `TypeError: Cannot read properties of undefined`). Suggested release: `v0-computation 0.16.0 → 0.17.0`. CHANGELOG.md updated accordingly.

## Test plan

- [x] `bun test` — 22/22 pass
- [x] `bun run build` — typecheck clean
- [ ] Verified locally in `frontend-dapp-v2` by overlaying the patched dist into `node_modules` (browser verification pending dapp dep bump after this lands)