### PR TITLE
chore(v0-computation): bump to 0.17.0

### DIFF
--- a/packages/v0-computation/package.json
+++ b/packages/v0-computation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-computation",
   "description": "Computation package that defines some Lagoon related computations utilities",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
## Summary

Minor version bump for `@lagoon-protocol/v0-computation`: **0.16.0 → 0.17.0**.

Releases the breaking-type change introduced by #69 (`computeAPR` return type widened to `number | undefined`, and `SimulationResult.periodNetApr` widened the same way).

Only `v0-computation` is bumped — `v0-core` and `v0-viem` have no changes since their last release.

## Why minor and not patch

In 0.x land the convention is "minor = breaking is acceptable, patch = no API change." This widens public types:

```diff
- function computeAPR(...): number
+ function computeAPR(...): number | undefined

  interface SimulationResult {
-   periodNetApr: number
+   periodNetApr?: number
    ...
  }
```

TypeScript consumers that do `apr.toFixed(2)` or assign to `number` will fail to compile. Untyped JS callers will hit `TypeError: Cannot read properties of undefined`. A patch bump under `^0.16` would silently auto-pull this; a minor bump under `^0.16` won't, giving consumers a deliberate choice.

CHANGELOG.md (already on main from #69) documents the migration.

## Test plan

- [x] `bun test` — 22/22 pass on main
- [x] `bun run build` — typecheck clean
- [ ] Publish to npm (separate manual step after merge)
- [ ] Bump `@lagoon-protocol/v0-computation` in `frontend-dapp-v2` (separate PR)