### PR TITLE
feat(v0-core): add LogicAdded and LogicRemoved events

### DIFF
--- a/packages/v0-core/package.json
+++ b/packages/v0-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-core",
   "description": "Framework-agnostic package that defines Lagoon related entity classes (such as Vault)",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/src/events/index.ts
+++ b/packages/v0-core/src/events/index.ts
@@ -2,4 +2,5 @@ export * from './vault/'
 export * from './factory/'
 export * from './proxy/'
 export * from './delayProxyAdmin/'
+export * from './logicRegistry/'
 export * from './Log';

--- a/packages/v0-core/src/events/logicRegistry/LogicAdded.ts
+++ b/packages/v0-core/src/events/logicRegistry/LogicAdded.ts
@@ -1,0 +1,23 @@
+import type { Address } from "../../types";
+import { Log, type ILog } from "../Log";
+
+interface ILogicAdded extends ILog {
+  logic: Address;
+}
+
+/**
+ * Emitted by `LogicRegistry.addLogic(_newLogic)` when a logic implementation
+ * is added to the whitelist of permitted logics.
+ */
+export class LogicAdded extends Log {
+  public readonly name: 'LogicAdded' = 'LogicAdded';
+  public readonly logic: Address;
+
+  constructor({
+    logic,
+    ...args
+  }: ILogicAdded) {
+    super(args);
+    this.logic = logic;
+  }
+}

--- a/packages/v0-core/src/events/logicRegistry/LogicRemoved.ts
+++ b/packages/v0-core/src/events/logicRegistry/LogicRemoved.ts
@@ -1,0 +1,23 @@
+import type { Address } from "../../types";
+import { Log, type ILog } from "../Log";
+
+interface ILogicRemoved extends ILog {
+  logic: Address;
+}
+
+/**
+ * Emitted by `LogicRegistry.removeLogic(_logic)` when a logic implementation
+ * is removed from the whitelist of permitted logics.
+ */
+export class LogicRemoved extends Log {
+  public readonly name: 'LogicRemoved' = 'LogicRemoved';
+  public readonly logic: Address;
+
+  constructor({
+    logic,
+    ...args
+  }: ILogicRemoved) {
+    super(args);
+    this.logic = logic;
+  }
+}

--- a/packages/v0-core/src/events/logicRegistry/index.ts
+++ b/packages/v0-core/src/events/logicRegistry/index.ts
@@ -1,0 +1,2 @@
+export * from './LogicAdded'
+export * from './LogicRemoved'

--- a/packages/v0-viem/package.json
+++ b/packages/v0-viem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-viem",
   "description": "Viem based package that defines Lagoon utilities for vault core classes",
-  "version": "0.18.2",
+  "version": "0.18.3",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",
@@ -38,7 +38,7 @@
     "vitest": "^3.2.3"
   },
   "peerDependencies": {
-    "@lagoon-protocol/v0-core": "^0.19.5",
+    "@lagoon-protocol/v0-core": "^0.19.6",
     "viem": "^2.0.0"
   },
   "private": false,


### PR DESCRIPTION
## Summary

- Adds \`LogicAdded\` and \`LogicRemoved\` event classes under \`v0-core/src/events/logicRegistry/\`, mirroring the on-chain events emitted by \`LogicRegistry\` (parent of \`ProtocolRegistry\`) when logic implementations are whitelisted or removed.
- Both events carry a single non-indexed \`logic: address\` field, matching the Solidity signatures in [\`LogicRegistry.sol\`](https://github.com/hopperlabsxyz/lagoon-v0/blob/main/src/protocol-v2/LogicRegistry.sol).
- Bumps \`@lagoon-protocol/v0-core\` to \`0.19.6\` and updates the \`v0-viem\` peer-dep range to \`^0.19.6\` (same pattern as PR #68).

Needed downstream by \`smeltery\` (lagoon/infrastructure) to index the available logic implementations into a new \`logics\` table.

## Test plan

- [x] \`bun run build\` succeeds for all three packages
- [x] \`bun test\` passes in v0-core (18 pass)
- [x] \`.d.ts\` exports verified — \`LogicAdded\` / \`LogicRemoved\` reachable via \`import { LogicAdded, LogicRemoved } from '@lagoon-protocol/v0-core'\`
- [ ] Publish \`v0-core@0.19.6\` and \`v0-viem@0.18.3\`