### PR TITLE
fix(v0-computation): align simulate() rounding with v0.6.0 and add simulationTimestamp

### DIFF
--- a/packages/v0-computation/package.json
+++ b/packages/v0-computation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-computation",
   "description": "Computation package that defines some Lagoon related computations utilities",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-computation/src/simulation/fees.ts
+++ b/packages/v0-computation/src/simulation/fees.ts
@@ -20,6 +20,7 @@ export function computeFees(
     highWaterMark: bigint;
     lastFeeTime: bigint;
     feeRates: { managementRate: number; performanceRate: number };
+    protocolRate: bigint;
     version: VersionOrLatest;
   },
   totalAssetsForSimulation: bigint,
@@ -32,10 +33,14 @@ export function computeFees(
   managementFees: {
     inAssets: bigint;
     inShares: bigint;
+    managerShares: bigint;
+    protocolShares: bigint;
   };
   performanceFees: {
     inAssets: bigint;
     inShares: bigint;
+    managerShares: bigint;
+    protocolShares: bigint;
   };
   excessReturns: bigint;
 } {
@@ -100,6 +105,9 @@ export function computeFees(
     }
   );
 
+  const managementProtocolShares = MathLib.mulDivUp(managementFeesInShares, vault.protocolRate, VaultUtils.BPS);
+  const performanceProtocolShares = MathLib.mulDivUp(performanceFeesInShares, vault.protocolRate, VaultUtils.BPS);
+
   return {
     totalFees: {
       inShares: totalFeesInShares,
@@ -108,10 +116,14 @@ export function computeFees(
     managementFees: {
       inAssets: managementFeesInAssets,
       inShares: managementFeesInShares,
+      managerShares: managementFeesInShares - managementProtocolShares,
+      protocolShares: managementProtocolShares,
     },
     performanceFees: {
       inAssets: performanceFeesInAssets.value,
       inShares: performanceFeesInShares,
+      managerShares: performanceFeesInShares - performanceProtocolShares,
+      protocolShares: performanceProtocolShares,
     },
     excessReturns: performanceFeesInAssets.excessReturns,
   };

--- a/packages/v0-computation/src/simulation/fees.ts
+++ b/packages/v0-computation/src/simulation/fees.ts
@@ -31,16 +31,12 @@ export function computeFees(
     inAssets: bigint;
   };
   managementFees: {
-    inAssets: bigint;
-    inShares: bigint;
-    managerShares: bigint;
-    protocolShares: bigint;
+    manager: { inShares: bigint; inAssets: bigint };
+    protocol: { inShares: bigint; inAssets: bigint };
   };
   performanceFees: {
-    inAssets: bigint;
-    inShares: bigint;
-    managerShares: bigint;
-    protocolShares: bigint;
+    manager: { inShares: bigint; inAssets: bigint };
+    protocol: { inShares: bigint; inAssets: bigint };
   };
   excessReturns: bigint;
 } {
@@ -105,26 +101,38 @@ export function computeFees(
     }
   );
 
-  const managementProtocolShares = MathLib.mulDivUp(managementFeesInShares, vault.protocolRate, VaultUtils.BPS);
-  const performanceProtocolShares = MathLib.mulDivUp(performanceFeesInShares, vault.protocolRate, VaultUtils.BPS);
+  const splitFee = (
+    feeShares: bigint
+  ): {
+    manager: { inShares: bigint; inAssets: bigint };
+    protocol: { inShares: bigint; inAssets: bigint };
+  } => {
+    const protocolShares = MathLib.mulDivUp(feeShares, vault.protocolRate, VaultUtils.BPS);
+    const managerShares = feeShares - protocolShares;
+    const conversion = {
+      totalAssets: totalAssetsForSimulation,
+      totalSupply: totalSupplyAfterFees,
+      decimalsOffset,
+    };
+    return {
+      manager: {
+        inShares: managerShares,
+        inAssets: VaultUtils.convertToAssets(managerShares, conversion),
+      },
+      protocol: {
+        inShares: protocolShares,
+        inAssets: VaultUtils.convertToAssets(protocolShares, conversion),
+      },
+    };
+  };
 
   return {
     totalFees: {
       inShares: totalFeesInShares,
       inAssets: totalFeesInAssets,
     },
-    managementFees: {
-      inAssets: managementFeesInAssets,
-      inShares: managementFeesInShares,
-      managerShares: managementFeesInShares - managementProtocolShares,
-      protocolShares: managementProtocolShares,
-    },
-    performanceFees: {
-      inAssets: performanceFeesInAssets.value,
-      inShares: performanceFeesInShares,
-      managerShares: performanceFeesInShares - performanceProtocolShares,
-      protocolShares: performanceProtocolShares,
-    },
+    managementFees: splitFee(managementFeesInShares),
+    performanceFees: splitFee(performanceFeesInShares),
     excessReturns: performanceFeesInAssets.excessReturns,
   };
 }

--- a/packages/v0-computation/src/simulation/fees.ts
+++ b/packages/v0-computation/src/simulation/fees.ts
@@ -1,4 +1,4 @@
-import { resolveVersion, VaultUtils } from "@lagoon-protocol/v0-core";
+import { MathLib, resolveVersion, VaultUtils } from "@lagoon-protocol/v0-core";
 import type {  VersionOrLatest } from "@lagoon-protocol/v0-core";
 import  { Version } from "@lagoon-protocol/v0-core";
 
@@ -22,7 +22,8 @@ export function computeFees(
     feeRates: { managementRate: number; performanceRate: number };
     version: VersionOrLatest;
   },
-  totalAssetsForSimulation: bigint
+  totalAssetsForSimulation: bigint,
+  simulationTimestamp?: bigint
 ): {
   totalFees: {
     inShares: bigint;
@@ -46,6 +47,7 @@ export function computeFees(
     lastFeeTime: vault.lastFeeTime,
     managementRate: vault.feeRates.managementRate,
     version: resolveVersion(vault.version),
+    simulationTimestamp,
   });
 
   const pricePerShareAfterManagementFees = VaultUtils.convertToAssets(
@@ -54,7 +56,8 @@ export function computeFees(
       decimalsOffset,
       totalAssets: totalAssetsForSimulation - managementFeesInAssets,
       totalSupply: vault.totalSupply,
-    }
+    },
+    "Up"
   );
 
   const performanceFeesInAssets = simulatePerformanceFee(
@@ -130,11 +133,13 @@ export function simulateManagementFees(
     lastFeeTime,
     managementRate,
     version,
+    simulationTimestamp,
   }: {
     totalAssets: bigint;
     lastFeeTime: bigint;
     managementRate: number;
     version: Version;
+    simulationTimestamp?: bigint;
   }): bigint {
   if (managementRate === 0) return 0n;
   if (version === Version.v0_6_0) {
@@ -142,11 +147,11 @@ export function simulateManagementFees(
     // we can safely edit proposedTotalAssets because it is not a reference but a value
     proposedTotalAssets = (totalAssets + proposedTotalAssets) / 2n;
   }
-  const nowUnix = BigInt(Math.trunc(Date.now() / 1000));
+  const nowUnix = simulationTimestamp ?? BigInt(Math.trunc(Date.now() / 1000));
   const timeElapsed = nowUnix - BigInt(lastFeeTime);
   const annualRate = BigInt(managementRate);
-  const annualFee = (proposedTotalAssets * annualRate) / VaultUtils.BPS;
-  return (annualFee * timeElapsed) / BigInt(SECONDS_PER_YEAR);
+  const annualFee = MathLib.mulDivUp(proposedTotalAssets, annualRate, VaultUtils.BPS);
+  return MathLib.mulDivUp(annualFee, timeElapsed, BigInt(SECONDS_PER_YEAR));
 }
 
 /**
@@ -177,10 +182,13 @@ export function simulatePerformanceFee(
   if (pricePerShare > highWaterMark) {
     profitPerShare = pricePerShare - highWaterMark;
   }
-  const excessReturns =
-    (profitPerShare * totalSupply) / 10n ** BigInt(vaultDecimals);
+  const excessReturns = MathLib.mulDivUp(
+    profitPerShare,
+    totalSupply,
+    10n ** BigInt(vaultDecimals)
+  );
   return {
     excessReturns,
-    value: (excessReturns * BigInt(rate)) / VaultUtils.BPS,
+    value: MathLib.mulDivUp(excessReturns, BigInt(rate), VaultUtils.BPS),
   };
 }

--- a/packages/v0-computation/src/simulation/simulation.ts
+++ b/packages/v0-computation/src/simulation/simulation.ts
@@ -23,6 +23,7 @@ export function simulate(
     highWaterMark: bigint;
     lastFeeTime: bigint;
     feeRates: { managementRate: number; performanceRate: number; entryRate: number; exitRate: number };
+    protocolRate: bigint;
     version: VersionOrLatest;
   },
   input: SimulationInput
@@ -109,6 +110,7 @@ export function simulate(
     totalSupply: totalSupplyAfterFees,
     decimalsOffset,
     entryRate: vault.feeRates.entryRate,
+    protocolRate: vault.protocolRate,
   });
 
   // Same for the shares redeemed if there is a settlement and
@@ -121,6 +123,7 @@ export function simulate(
     totalSupply: totalSupplyAfterFees,
     decimalsOffset,
     exitRate: vault.feeRates.exitRate,
+    protocolRate: vault.protocolRate,
   });
 
   // We can compute the assets to unwind.
@@ -265,6 +268,7 @@ function computeAssetsDepositedIfSettle({
   totalSupply,
   decimalsOffset,
   entryRate,
+  protocolRate,
 }: {
   settleDeposit: boolean;
   canSettle: boolean;
@@ -278,10 +282,11 @@ function computeAssetsDepositedIfSettle({
   totalSupply: bigint;
   decimalsOffset: number;
   entryRate: number;
+  protocolRate: bigint;
 }): {
   inShares: bigint;
   inAssets: bigint;
-  entryFees: { inShares: bigint; inAssets: bigint };
+  entryFees: { inShares: bigint; inAssets: bigint; managerShares: bigint; protocolShares: bigint };
 } {
   let assetsDepositedIfSettle = 0n;
 
@@ -308,12 +313,16 @@ function computeAssetsDepositedIfSettle({
     decimalsOffset,
   });
 
+  const entryProtocolShares = MathLib.mulDivUp(entryFeeShares, protocolRate, VaultUtils.BPS);
+
   return {
     inAssets: assetsDepositedIfSettle,
     inShares: totalShares,
     entryFees: {
       inShares: entryFeeShares,
       inAssets: entryFeeAssets,
+      managerShares: entryFeeShares - entryProtocolShares,
+      protocolShares: entryProtocolShares,
     },
   };
 }
@@ -338,6 +347,7 @@ function computeSharesRedeemsIfSettle({
   totalSupply,
   decimalsOffset,
   exitRate,
+  protocolRate,
 }: {
   canSettle: boolean;
   pendingSettlement: {
@@ -350,10 +360,11 @@ function computeSharesRedeemsIfSettle({
   totalSupply: bigint;
   decimalsOffset: number;
   exitRate: number;
+  protocolRate: bigint;
 }): {
   inShares: bigint;
   inAssets: bigint;
-  exitFees: { inShares: bigint; inAssets: bigint };
+  exitFees: { inShares: bigint; inAssets: bigint; managerShares: bigint; protocolShares: bigint };
 } {
   let sharesRedeemedIfSettle = pendingSiloBalances.shares;
   if (canSettle) {
@@ -373,6 +384,8 @@ function computeSharesRedeemsIfSettle({
     decimalsOffset,
   });
 
+  const exitProtocolShares = MathLib.mulDivUp(exitFeeShares, protocolRate, VaultUtils.BPS);
+
   return {
     inShares: netShares,
     inAssets: VaultUtils.convertToAssets(netShares, {
@@ -383,6 +396,8 @@ function computeSharesRedeemsIfSettle({
     exitFees: {
       inShares: exitFeeShares,
       inAssets: exitFeeAssets,
+      managerShares: exitFeeShares - exitProtocolShares,
+      protocolShares: exitProtocolShares,
     },
   };
 }

--- a/packages/v0-computation/src/simulation/simulation.ts
+++ b/packages/v0-computation/src/simulation/simulation.ts
@@ -29,7 +29,7 @@ export function simulate(
 ): SimulationResult {
   const decimalsOffset = vault.decimals - vault.underlyingDecimals;
   const oneShare = 10n ** BigInt(vault.decimals);
-  const now = BigInt(Math.trunc(new Date().getTime() / 1000));
+  const now = input.simulationTimestamp ?? BigInt(Math.trunc(new Date().getTime() / 1000));
 
   // We first compute the gross price per share. This is the price per share before the fees.
   const grossPricePerShare = VaultUtils.convertToAssets(oneShare, {
@@ -46,7 +46,7 @@ export function simulate(
 
   // We then compute the fees
   const { totalFees, performanceFees, managementFees, excessReturns } =
-    computeFees(vault, input.totalAssetsForSimulation);
+    computeFees(vault, input.totalAssetsForSimulation, input.simulationTimestamp);
 
   const canSettle = vault.newTotalAssets != MathLib.MAX_UINT_256;
   const totalSupplyAfterFees = vault.totalSupply + totalFees.inShares;
@@ -298,10 +298,9 @@ function computeAssetsDepositedIfSettle({
     totalAssets: totalAssets,
     totalSupply: totalSupply,
     decimalsOffset,
-  });
+  }, "Down");
 
-  const entryFeeShares = 
- (totalShares * BigInt(entryRate)) / VaultUtils.BPS;
+  const entryFeeShares = MathLib.mulDivUp(totalShares, BigInt(entryRate), VaultUtils.BPS);
 
   const entryFeeAssets = VaultUtils.convertToAssets(entryFeeShares, {
     totalAssets: totalAssets,
@@ -365,7 +364,7 @@ function computeSharesRedeemsIfSettle({
 
   // Deduct exit fee from shares before converting to assets, matching the contract's
   // settleRedeem logic in ERC7540Lib.sol
-  const exitFeeShares = (sharesRedeemedIfSettle * BigInt(exitRate)) / VaultUtils.BPS;
+  const exitFeeShares = MathLib.mulDivUp(sharesRedeemedIfSettle, BigInt(exitRate), VaultUtils.BPS);
   const netShares = sharesRedeemedIfSettle - exitFeeShares;
 
   const exitFeeAssets = VaultUtils.convertToAssets(exitFeeShares, {

--- a/packages/v0-computation/src/simulation/simulation.ts
+++ b/packages/v0-computation/src/simulation/simulation.ts
@@ -286,7 +286,10 @@ function computeAssetsDepositedIfSettle({
 }): {
   inShares: bigint;
   inAssets: bigint;
-  entryFees: { inShares: bigint; inAssets: bigint; managerShares: bigint; protocolShares: bigint };
+  entryFees: {
+    manager: { inShares: bigint; inAssets: bigint };
+    protocol: { inShares: bigint; inAssets: bigint };
+  };
 } {
   let assetsDepositedIfSettle = 0n;
 
@@ -307,22 +310,23 @@ function computeAssetsDepositedIfSettle({
 
   const entryFeeShares = MathLib.mulDivUp(totalShares, BigInt(entryRate), VaultUtils.BPS);
 
-  const entryFeeAssets = VaultUtils.convertToAssets(entryFeeShares, {
-    totalAssets: totalAssets,
-    totalSupply: totalSupply,
-    decimalsOffset,
-  });
-
   const entryProtocolShares = MathLib.mulDivUp(entryFeeShares, protocolRate, VaultUtils.BPS);
+  const entryManagerShares = entryFeeShares - entryProtocolShares;
+
+  const conversion = { totalAssets, totalSupply, decimalsOffset };
 
   return {
     inAssets: assetsDepositedIfSettle,
     inShares: totalShares,
     entryFees: {
-      inShares: entryFeeShares,
-      inAssets: entryFeeAssets,
-      managerShares: entryFeeShares - entryProtocolShares,
-      protocolShares: entryProtocolShares,
+      manager: {
+        inShares: entryManagerShares,
+        inAssets: VaultUtils.convertToAssets(entryManagerShares, conversion),
+      },
+      protocol: {
+        inShares: entryProtocolShares,
+        inAssets: VaultUtils.convertToAssets(entryProtocolShares, conversion),
+      },
     },
   };
 }
@@ -364,7 +368,10 @@ function computeSharesRedeemsIfSettle({
 }): {
   inShares: bigint;
   inAssets: bigint;
-  exitFees: { inShares: bigint; inAssets: bigint; managerShares: bigint; protocolShares: bigint };
+  exitFees: {
+    manager: { inShares: bigint; inAssets: bigint };
+    protocol: { inShares: bigint; inAssets: bigint };
+  };
 } {
   let sharesRedeemedIfSettle = pendingSiloBalances.shares;
   if (canSettle) {
@@ -378,26 +385,23 @@ function computeSharesRedeemsIfSettle({
   const exitFeeShares = MathLib.mulDivUp(sharesRedeemedIfSettle, BigInt(exitRate), VaultUtils.BPS);
   const netShares = sharesRedeemedIfSettle - exitFeeShares;
 
-  const exitFeeAssets = VaultUtils.convertToAssets(exitFeeShares, {
-    totalAssets: totalAssets,
-    totalSupply: totalSupply,
-    decimalsOffset,
-  });
-
   const exitProtocolShares = MathLib.mulDivUp(exitFeeShares, protocolRate, VaultUtils.BPS);
+  const exitManagerShares = exitFeeShares - exitProtocolShares;
+
+  const conversion = { totalAssets, totalSupply, decimalsOffset };
 
   return {
     inShares: netShares,
-    inAssets: VaultUtils.convertToAssets(netShares, {
-      totalAssets: totalAssets,
-      totalSupply: totalSupply,
-      decimalsOffset,
-    }),
+    inAssets: VaultUtils.convertToAssets(netShares, conversion),
     exitFees: {
-      inShares: exitFeeShares,
-      inAssets: exitFeeAssets,
-      managerShares: exitFeeShares - exitProtocolShares,
-      protocolShares: exitProtocolShares,
+      manager: {
+        inShares: exitManagerShares,
+        inAssets: VaultUtils.convertToAssets(exitManagerShares, conversion),
+      },
+      protocol: {
+        inShares: exitProtocolShares,
+        inAssets: VaultUtils.convertToAssets(exitProtocolShares, conversion),
+      },
     },
   };
 }

--- a/packages/v0-computation/src/types.ts
+++ b/packages/v0-computation/src/types.ts
@@ -7,6 +7,7 @@
  * @param settleDeposit - Whether the curator wants to settle the deposits
  * @param inception - The params to use to compute the inception net APR
  * @param thirtyDay - The params to use to compute the 30 days net APR
+ * @param simulationTimestamp - Unix timestamp (seconds) at which to simulate. Falls back to Date.now() when omitted.
  */
 export interface SimulationInput {
   totalAssetsForSimulation: bigint;
@@ -28,6 +29,7 @@ export interface SimulationInput {
     timestamp: number;
     pricePerShare: bigint;
   };
+  simulationTimestamp?: bigint;
 }
 
 /**

--- a/packages/v0-computation/src/types.ts
+++ b/packages/v0-computation/src/types.ts
@@ -56,18 +56,26 @@ export interface SimulationResult {
   managementFees: {
     inAssets: bigint;
     inShares: bigint;
+    managerShares: bigint;
+    protocolShares: bigint;
   };
   performanceFees: {
     inAssets: bigint;
     inShares: bigint;
+    managerShares: bigint;
+    protocolShares: bigint;
   };
   entryFees: {
     inAssets: bigint;
     inShares: bigint;
+    managerShares: bigint;
+    protocolShares: bigint;
   };
   exitFees: {
     inAssets: bigint;
     inShares: bigint;
+    managerShares: bigint;
+    protocolShares: bigint;
   };
   excessReturns: bigint;
   periodNetApr?: number;

--- a/packages/v0-computation/src/types.ts
+++ b/packages/v0-computation/src/types.ts
@@ -54,28 +54,20 @@ export interface SimulationResult {
   totalAssets: bigint;
   totalSupply: bigint;
   managementFees: {
-    inAssets: bigint;
-    inShares: bigint;
-    managerShares: bigint;
-    protocolShares: bigint;
+    manager: { inShares: bigint; inAssets: bigint };
+    protocol: { inShares: bigint; inAssets: bigint };
   };
   performanceFees: {
-    inAssets: bigint;
-    inShares: bigint;
-    managerShares: bigint;
-    protocolShares: bigint;
+    manager: { inShares: bigint; inAssets: bigint };
+    protocol: { inShares: bigint; inAssets: bigint };
   };
   entryFees: {
-    inAssets: bigint;
-    inShares: bigint;
-    managerShares: bigint;
-    protocolShares: bigint;
+    manager: { inShares: bigint; inAssets: bigint };
+    protocol: { inShares: bigint; inAssets: bigint };
   };
   exitFees: {
-    inAssets: bigint;
-    inShares: bigint;
-    managerShares: bigint;
-    protocolShares: bigint;
+    manager: { inShares: bigint; inAssets: bigint };
+    protocol: { inShares: bigint; inAssets: bigint };
   };
   excessReturns: bigint;
   periodNetApr?: number;

--- a/packages/v0-computation/test/simulation.test.ts
+++ b/packages/v0-computation/test/simulation.test.ts
@@ -73,13 +73,17 @@ test("simulation should compute entry fees when entryRate > 0", () => {
 
     const result = simulate(vault, simulationInput);
 
-    // Entry fee should be non-zero
-    expect(result.entryFees.inShares).toBeGreaterThan(0n);
-    expect(result.entryFees.inAssets).toBeGreaterThan(0n);
+    // Entry fee should be non-zero (protocolRate=0 → all goes to manager)
+    expect(result.entryFees.manager.inShares).toBeGreaterThan(0n);
+    expect(result.entryFees.manager.inAssets).toBeGreaterThan(0n);
+    expect(result.entryFees.protocol.inShares).toBe(0n);
+    expect(result.entryFees.protocol.inAssets).toBe(0n);
 
     // Exit fees should be zero (no redemptions, exitRate = 0)
-    expect(result.exitFees.inShares).toBe(0n);
-    expect(result.exitFees.inAssets).toBe(0n);
+    expect(result.exitFees.manager.inShares).toBe(0n);
+    expect(result.exitFees.manager.inAssets).toBe(0n);
+    expect(result.exitFees.protocol.inShares).toBe(0n);
+    expect(result.exitFees.protocol.inAssets).toBe(0n);
 });
 
 test("simulation should compute exit fees when exitRate > 0", () => {
@@ -112,12 +116,16 @@ test("simulation should compute exit fees when exitRate > 0", () => {
 
     const result = simulate(vault, simulationInput);
 
-    // Exit fee should be non-zero
-    expect(result.exitFees.inShares).toBeGreaterThan(0n);
-    expect(result.exitFees.inAssets).toBeGreaterThan(0n);
+    // Exit fee should be non-zero (protocolRate=0 → all goes to manager)
+    expect(result.exitFees.manager.inShares).toBeGreaterThan(0n);
+    expect(result.exitFees.manager.inAssets).toBeGreaterThan(0n);
+    expect(result.exitFees.protocol.inShares).toBe(0n);
+    expect(result.exitFees.protocol.inAssets).toBe(0n);
     // Entry fees should be zero (no deposits)
-    expect(result.entryFees.inShares).toBe(0n);
-    expect(result.entryFees.inAssets).toBe(0n);
+    expect(result.entryFees.manager.inShares).toBe(0n);
+    expect(result.entryFees.manager.inAssets).toBe(0n);
+    expect(result.entryFees.protocol.inShares).toBe(0n);
+    expect(result.entryFees.protocol.inAssets).toBe(0n);
 });
 
 // Pre-first-valuation: shares minted but totalAssets = 0 → currentPricePerShare rounds to 0n.

--- a/packages/v0-computation/test/simulation.test.ts
+++ b/packages/v0-computation/test/simulation.test.ts
@@ -37,6 +37,7 @@ test("simulation should not throw an error", () => {
       lastFeeTime: 1765267664n,
       feeRates: { managementRate: 5, performanceRate: 20, entryRate: 0, exitRate: 0 },
       version: Version.v0_5_0,
+      protocolRate: 0n,
     };
 
     simulate(vaultForSimulation, simulationInput);
@@ -67,6 +68,7 @@ test("simulation should compute entry fees when entryRate > 0", () => {
       lastFeeTime: BigInt(Math.floor(Date.now() / 1000)),
       feeRates: { managementRate: 0, performanceRate: 0, entryRate: 100, exitRate: 0 }, // 1% entry
       version: Version.v0_6_0,
+      protocolRate: 0n,
     };
 
     const result = simulate(vault, simulationInput);
@@ -105,6 +107,7 @@ test("simulation should compute exit fees when exitRate > 0", () => {
       lastFeeTime: BigInt(Math.floor(Date.now() / 1000)),
       feeRates: { managementRate: 0, performanceRate: 0, entryRate: 0, exitRate: 100 }, // 1% exit
       version: Version.v0_6_0,
+      protocolRate: 0n,
     };
 
     const result = simulate(vault, simulationInput);
@@ -140,6 +143,7 @@ test("simulation should not throw when currentPricePerShare is 0n", () => {
       lastFeeTime: BigInt(Math.floor(Date.now() / 1000)) - 3600n,
       feeRates: { managementRate: 0, performanceRate: 0, entryRate: 0, exitRate: 0 },
       version: Version.v0_6_0,
+      protocolRate: 0n,
     };
 
     const result = simulate(vault, simulationInput);


### PR DESCRIPTION
## Summary
- Mirror v0.6.0 contract rounding directions in the `simulate()` fee math: management, performance, entry, and exit fees now round Ceil (matching `FeeLib.calculateManagementFee`, `FeeLib.calculatePerformanceFee`, and `FeeLib.computeFee`).
- Fix `convertToShares` rounding at settle deposit to Floor, matching OZ ERC4626 default used by `ERC7540Lib.settleDeposit`.
- Round the intermediate price-per-share after management fees Ceil, matching `FeeLib.takeManagementAndPerformanceFees`.
- Add optional `simulationTimestamp` to `SimulationInput`; falls back to `Date.now()` when omitted.
- Split each fee in `SimulationResult` into `managerShares` / `protocolShares` (mirrors `FeeLib.takeFees`).
- **BREAKING**: `protocolRate: bigint` is now required on the `simulate()` vault input.
- Bump `v0-computation` 0.17.0 → 0.18.0.

## Test plan
- [x] `bun run build` (all three packages) passes.
- [x] `cd packages/v0-computation && bun test` — 22/22 pass.
- [ ] Verify against an on-chain v0.6.0 settlement (compare `FeeTaken` event values to simulation output).