### PR TITLE
chore(v0-core): restrict v0.6.0 addresses to deployed networks

### DIFF
--- a/packages/v0-computation/package.json
+++ b/packages/v0-computation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-computation",
   "description": "Computation package that defines some Lagoon related computations utilities",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/package.json
+++ b/packages/v0-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-core",
   "description": "Framework-agnostic package that defines Lagoon related entity classes (such as Vault)",
-  "version": "0.19.6",
+  "version": "0.19.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/src/addresses.ts
+++ b/packages/v0-core/src/addresses.ts
@@ -8,7 +8,7 @@ export const addresses = {
   [ChainId.EthMainnet]: {
     beaconProxyFactory: "0x09C8803f7Dc251f9FaAE5f56E3B91f8A6d0b70ee",
     feeRegistry: "0x6dA4D1859bA1d02D095D2246142CdAd52233e27C",
-    "v0_6_0": "0xfa74576133e64c84E24F3a8205c9C69a02053e1C",
+    "v0_6_0": "0xf8ce398f05849a00a962de8de16a0af6aff60eb1",
     "v0_5_0": "0xe50554ec802375c9c3f9c087a8a7bb8c26d3dedf",
     wrappedNative: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     optinFactory: "0x8D6f5479B14348186faE9BC7E636e947c260f9B1"
@@ -16,7 +16,7 @@ export const addresses = {
   [ChainId.ArbitrumMainnet]: {
     beaconProxyFactory: "0x58a7729125acA9e5E9C687018E66bfDd5b2D4490",
     feeRegistry: "0x6dA4D1859bA1d02D095D2246142CdAd52233e27C",
-    "v0_6_0": "0xc2344A58e450aD30dEF780A6641c0A90F50B0dbd",
+    "v0_6_0": "0xdf56ee5b276e51be4a7c8fd781fc77dbe4cee6ba",
     "v0_5_0": "0xE50554ec802375C9c3F9c087a8a7bb8C26d3DEDf",
     wrappedNative: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
     /**
@@ -31,7 +31,7 @@ export const addresses = {
   [ChainId.BaseMainnet]: {
     beaconProxyFactory: "0xC953Fd298FdfA8Ed0D38ee73772D3e21Bf19c61b",
     feeRegistry: "0x6dA4D1859bA1d02D095D2246142CdAd52233e27C",
-    "v0_6_0": "0x9De724B0efEe0FbA07FE21a16B9Bf9bBb5204Fb4",
+    "v0_6_0": "0x332db9557fef23ddbc0dba48f261a93ac9ee4a75",
     "v0_5_0": "0xE50554ec802375C9c3F9c087a8a7bb8C26d3DEDf",
     wrappedNative: "0x4200000000000000000000000000000000000006",
     optinFactory: "0x6FC0F2320483fa03FBFdF626DDbAE2CC4B112b51"
@@ -54,7 +54,7 @@ export const addresses = {
   [ChainId.SonicMainnet]: {
     beaconProxyFactory: "0x99CD0b8b32B15922f0754Fddc21323b5278c5261",
     feeRegistry: "0xab4aC28D10a4Bc279aD073B1D74Bfa0E385C010C",
-    "v0_6_0": "0xfa74576133e64c84E24F3a8205c9C69a02053e1C",
+    "v0_6_0": "0x0000000000000000000000000000000000000000",
     "v0_5_0": "0xE50554ec802375C9c3F9c087a8a7bb8C26d3DEDf",
     wrappedNative: "0x039e2fB66102314Ce7b64Ce5Ce3E5183bc94aD38",
     optinFactory: "0x6FC0F2320483fa03FBFdF626DDbAE2CC4B112b51"
@@ -70,7 +70,7 @@ export const addresses = {
   [ChainId.WorldChainMainnet]: {
     beaconProxyFactory: "0x600fA26581771F56221FC9847A834B3E5fd34AF7",
     feeRegistry: "0x68e793658def657551fd4D3cA6Bc04b4E7723655",
-    "v0_6_0": "0xfa74576133e64c84E24F3a8205c9C69a02053e1C",
+    "v0_6_0": "0x0000000000000000000000000000000000000000",
     "v0_5_0": "0x1D42DbDde553F4099691A25F712bbd8f2686E355",
     wrappedNative: "0x4200000000000000000000000000000000000006",
     optinFactory: "0xC094C224ce0406BC338E00837B96aD2e265F7287"
@@ -78,7 +78,7 @@ export const addresses = {
   [ChainId.AvalancheMainnet]: {
     beaconProxyFactory: "0x5e231c6d030a5c0f51fa7d0f891d3f50a928c685",
     feeRegistry: "0xD7F69ba99c6981Eab5579Aa16871Ae94c509d578",
-    "v0_6_0": "0x0000000000000000000000000000000000000000",
+    "v0_6_0": "0xfa74576133e64c84e24f3a8205c9c69a02053e1c",
     "v0_5_0": "0x33F65C8D025b5418C7f8dd248C2Ec1d31881D465",
     wrappedNative: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
     optinFactory: "0xC094C224ce0406BC338E00837B96aD2e265F7287"
@@ -99,7 +99,7 @@ export const addresses = {
   },
   [ChainId.BscMainnet]: {
     feeRegistry: "0x9c275714Fb882988FbbFfdc39a162E0cc9feA64c",
-    "v0_6_0": "0xfa74576133e64c84E24F3a8205c9C69a02053e1C",
+    "v0_6_0": "0x0000000000000000000000000000000000000000",
     "v0_5_0": "0x7175E7E5C246e2E5c8C54Ede2ee0180e39fcA879",
     wrappedNative: "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
     optinFactory: "0x3f680aB9E51EEED9381dE5275f4995611Ff884d5"
@@ -113,7 +113,7 @@ export const addresses = {
   [ChainId.LineaMainnet]: {
     feeRegistry: "0xC81Dd51239119Db80D5a6E1B7347F3C3BC8674d9",
     "v0_4_0": "0xC094C224ce0406BC338E00837B96aD2e265F7287",
-    "v0_6_0": "0xfF04a00Cb539617ff2AbBF23AEE037A1C52Bc5d5",
+    "v0_6_0": "0x0000000000000000000000000000000000000000",
     "v0_5_0": "0xA3C233C61436008e05EDdE6adb3f81a410fa80C2",
     wrappedNative: "0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f",
     optinFactory: "0x8D6f5479B14348186faE9BC7E636e947c260f9B1"
@@ -126,7 +126,7 @@ export const addresses = {
   },
   [ChainId.PolygonMainnet]: {
     feeRegistry: "0x744F9cA26CD9F6Be5cf79A00b1Ad457145D9F691",
-    "v0_6_0": "0xfa74576133e64c84E24F3a8205c9C69a02053e1C",
+    "v0_6_0": "0x0000000000000000000000000000000000000000",
     "v0_5_0": "0x50f30E712D535b796C8543012D0C05218b89c7d5",
     wrappedNative: "0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270",
     optinFactory: "0x0C0E287f6e4de685f4b44A5282A3ad4A29D05a91"
@@ -145,7 +145,7 @@ export const addresses = {
   },
   [ChainId.OptimismMainnet]: {
     feeRegistry: "0x7AB55B30e3c382451FCCa104521a8B5F45bEeaf9",
-    "v0_6_0": "0xfa74576133e64c84E24F3a8205c9C69a02053e1C",
+    "v0_6_0": "0x0000000000000000000000000000000000000000",
     "v0_5_0": "0xBB2dcC67A94946400a605F2a97933471bE8BC538",
     wrappedNative: "0x4200000000000000000000000000000000000006",
     optinFactory: "0xA8E0684887b9475f8942DF6a89bEBa5B25219632"
@@ -153,7 +153,7 @@ export const addresses = {
   [ChainId.HemiMainnet]: {
     feeRegistry: "0x35723a53cCB5AdecFBcf50Cd1b190e15D896c389",
     "v0_5_0": "0xE35901b2a7D8d38A0E49D9BC9dE7F4f9dF31Cc6d",
-    "v0_6_0": "0xfA032DE1214fD89b465c306BF46F778318bDe357",
+    "v0_6_0": "0x0000000000000000000000000000000000000000",
     wrappedNative: "0x4200000000000000000000000000000000000006",
     optinFactory: "0xB457e9C025A8Af99E32b03668e34f80D20A71d2C"
   }

--- a/packages/v0-viem/package.json
+++ b/packages/v0-viem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-viem",
   "description": "Viem based package that defines Lagoon utilities for vault core classes",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
## Summary
- Set real v0.6.0 addresses for Ethereum, Arbitrum, Base, and Avalanche
- Zero out v0.6.0 addresses on all other chains where it was previously set (Sonic, WorldChain, BSC, Linea, Polygon, Optimism, Hemi)

| Chain | v0.6.0 address |
|-------|----------------|
| Ethereum | 0xf8ce398f05849a00a962de8de16a0af6aff60eb1 |
| Arbitrum | 0xdf56ee5b276e51be4a7c8fd781fc77dbe4cee6ba |
| Base | 0x332db9557fef23ddbc0dba48f261a93ac9ee4a75 |
| Avalanche | 0xfa74576133e64c84e24f3a8205c9c69a02053e1c |
| All others | 0x0000...0000 |

## Test plan
- [ ] `bun run build` succeeds
- [ ] Confirm consumers handle zero-address `v0_6_0` correctly on chains without a deployment