### PR TITLE
version bump

### DIFF
--- a/packages/v0-computation/package.json
+++ b/packages/v0-computation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-computation",
   "description": "Computation package that defines some Lagoon related computations utilities",
-  "version": "0.18.1",
+  "version": "0.18.2",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
## Summary
- Bump `@lagoon-protocol/v0-computation` from 0.18.1 → 0.18.2 to publish the `aprToBound` / `boundToApr` helpers (Guardrails) added in #75.

## Test plan
- [x] `bun run re` passes
- [x] `bun run test` (v0-computation) passes