### PR TITLE
feat: register Rayls mainnet (chain 72957)

### DIFF
--- a/packages/v0-computation/package.json
+++ b/packages/v0-computation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-computation",
   "description": "Computation package that defines some Lagoon related computations utilities",
-  "version": "0.18.6",
+  "version": "0.18.7",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/package.json
+++ b/packages/v0-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-core",
   "description": "Framework-agnostic package that defines Lagoon related entity classes (such as Vault)",
-  "version": "0.19.12",
+  "version": "0.19.13",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/src/addresses.ts
+++ b/packages/v0-core/src/addresses.ts
@@ -176,5 +176,12 @@ export const addresses = {
     wrappedNative: "0x4200000000000000000000000000000000000006",
     optinFactory: "0xB457e9C025A8Af99E32b03668e34f80D20A71d2C",
     isOptinFactoryV3: false,
+  },
+  [ChainId.RaylsMainnet]: {
+    feeRegistry: "0x70cfb8860933C7aB2e3C92c942f403AF0941F96B",
+    "v0_5_1": "0xfF04a00Cb539617ff2AbBF23AEE037A1C52Bc5d5",
+    wrappedNative: "0x0000000000000000000000000000000000000400",
+    optinFactory: "0xfA032DE1214fD89b465c306BF46F778318bDe357",
+    isOptinFactoryV3: true,
   }
 } as const satisfies Record<ChainId, unknown>;

--- a/packages/v0-core/src/chain.ts
+++ b/packages/v0-core/src/chain.ts
@@ -19,6 +19,7 @@ export enum ChainId {
   MonadMainnet = 143,
   SeiMainnet = 1329,
   HemiMainnet = 43111,
+  RaylsMainnet = 72957,
 }
 
 export interface ChainMetadata {
@@ -190,6 +191,13 @@ export namespace ChainUtils {
       nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
       explorerUrl: "https://explorer.hemi.xyz",
       identifier: "hemi",
+    },
+    [ChainId.RaylsMainnet]: {
+      name: "Rayls",
+      id: ChainId.RaylsMainnet,
+      nativeCurrency: { name: "USD Rayls", symbol: "USDr", decimals: 18 },
+      explorerUrl: "https://explorer.rayls.com",
+      identifier: "rayls",
     }
   } as const
 }

--- a/packages/v0-viem/package.json
+++ b/packages/v0-viem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-viem",
   "description": "Viem based package that defines Lagoon utilities for vault core classes",
-  "version": "0.18.9",
+  "version": "0.18.10",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
## Summary
- Adds `RaylsMainnet = 72957` to the `ChainId` enum with display metadata (Rayls, USDr / USD Rayls / 18 decimals, https://explorer.rayls.com).
- Adds the per-chain Lagoon deployment addresses: `feeRegistry`, `v0_5_1` vault logic, `wrappedNative`, `optinFactory` (V3).
- First chain to use the `v0_5_1` key in `addresses.ts` — the `Version` enum already supports `v0_5_1`.
- Bumps packages: v0-core 0.19.13, v0-viem 0.18.10, v0-computation 0.18.7.

## Deployment values

| Field | Value |
|---|---|
| Chain ID | 72957 |
| RPC | https://mainnet-rpc.rayls.com |
| Explorer | https://explorer.rayls.com |
| Native | USDr (USD Rayls, 18 decimals) |
| feeRegistry | `0x70cfb8860933C7aB2e3C92c942f403AF0941F96B` |
| wrappedNative | `0x0000000000000000000000000000000000000400` |
| optinFactory (V3) | `0xfA032DE1214fD89b465c306BF46F778318bDe357` |
| v0_5_1 logic | `0xfF04a00Cb539617ff2AbBF23AEE037A1C52Bc5d5` |

## Test plan
- [x] `bun run build` succeeds across v0-core / v0-viem / v0-computation
- [x] `bun test` in v0-core (21/21)
- [x] `bun run test` in v0-computation (31/31)
- [x] `bun run test` in v0-viem completes with exit 0