### PR TITLE
feat(v0-core): set v0.6.0 deployment addresses for 5 chains

### DIFF
--- a/packages/v0-core/package.json
+++ b/packages/v0-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-core",
   "description": "Framework-agnostic package that defines Lagoon related entity classes (such as Vault)",
-  "version": "0.19.14",
+  "version": "0.19.15",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/src/addresses.ts
+++ b/packages/v0-core/src/addresses.ts
@@ -8,7 +8,7 @@ export const addresses = {
   [ChainId.EthMainnet]: {
     beaconProxyFactory: "0x09C8803f7Dc251f9FaAE5f56E3B91f8A6d0b70ee",
     feeRegistry: "0x6dA4D1859bA1d02D095D2246142CdAd52233e27C",
-    "v0_6_0": "0x0000000000000000000000000000000000000000",
+    "v0_6_0": "0x6C77c47FB8168E22976C3B0338CB1769c952249f",
     "v0_5_0": "0xe50554ec802375c9c3f9c087a8a7bb8c26d3dedf",
     wrappedNative: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
     optinFactory: "0x8D6f5479B14348186faE9BC7E636e947c260f9B1",
@@ -17,7 +17,7 @@ export const addresses = {
   [ChainId.ArbitrumMainnet]: {
     beaconProxyFactory: "0x58a7729125acA9e5E9C687018E66bfDd5b2D4490",
     feeRegistry: "0x6dA4D1859bA1d02D095D2246142CdAd52233e27C",
-    "v0_6_0": "0x0000000000000000000000000000000000000000",
+    "v0_6_0": "0x3f5A9e1D82c595d14bA93c97eB8a77928cFdee70",
     "v0_5_0": "0xE50554ec802375C9c3F9c087a8a7bb8C26d3DEDf",
     wrappedNative: "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",
     /**
@@ -33,7 +33,7 @@ export const addresses = {
   [ChainId.BaseMainnet]: {
     beaconProxyFactory: "0xC953Fd298FdfA8Ed0D38ee73772D3e21Bf19c61b",
     feeRegistry: "0x6dA4D1859bA1d02D095D2246142CdAd52233e27C",
-    "v0_6_0": "0x0000000000000000000000000000000000000000",
+    "v0_6_0": "0xd04DeaBa7fD06634764CbFfe140011C69063aC77",
     "v0_5_0": "0xE50554ec802375C9c3F9c087a8a7bb8C26d3DEDf",
     wrappedNative: "0x4200000000000000000000000000000000000006",
     optinFactory: "0x6FC0F2320483fa03FBFdF626DDbAE2CC4B112b51",
@@ -86,7 +86,7 @@ export const addresses = {
   [ChainId.AvalancheMainnet]: {
     beaconProxyFactory: "0x5e231c6d030a5c0f51fa7d0f891d3f50a928c685",
     feeRegistry: "0xD7F69ba99c6981Eab5579Aa16871Ae94c509d578",
-    "v0_6_0": "0x0000000000000000000000000000000000000000",
+    "v0_6_0": "0x41669dB18dD923f726572cCFd4B1929e203fCC9d",
     "v0_5_0": "0x33F65C8D025b5418C7f8dd248C2Ec1d31881D465",
     wrappedNative: "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7",
     optinFactory: "0xC094C224ce0406BC338E00837B96aD2e265F7287",
@@ -118,6 +118,7 @@ export const addresses = {
   },
   [ChainId.HyperEVMMainnet]: {
     feeRegistry: "0xd70937AA2B73A8a2100932c4f5a8D32c9bE8b80f",
+    "v0_6_0": "0x23f4966ab6418cd54c95ec807a842a5f1ed9ef03",
     "v0_5_0": "0xC1D5F01A6491b97B94F3670Aed4BEcB897293CF8",
     wrappedNative: "0x5555555555555555555555555555555555555555",
     optinFactory: "0x90beB507A1BA7D64633540cbce615B574224CD84",


### PR DESCRIPTION
## Summary
- Set the deployed v0.6.0 vault implementation addresses (previously zeroed-out placeholders) for Ethereum, Arbitrum, Base, Avalanche, and HyperEVM.
- HyperEVM had no `v0_6_0` key yet — added it before `v0_5_0` to match the ordering convention.
- Bump `@lagoon-protocol/v0-core` to 0.19.15.

| Chain | v0.6.0 address |
|-------|----------------|
| Ethereum | `0x6C77c47FB8168E22976C3B0338CB1769c952249f` |
| Base | `0xd04DeaBa7fD06634764CbFfe140011C69063aC77` |
| Arbitrum | `0x3f5A9e1D82c595d14bA93c97eB8a77928cFdee70` |
| Avalanche | `0x41669dB18dD923f726572cCFd4B1929e203fCC9d` |
| HyperEVM | `0x23f4966ab6418cd54c95ec807a842a5f1ed9ef03` |

## Test plan
- [x] `bun run build` passes for all three packages