### PR TITLE
fix(v0-core): mark HyperEVM OptinProxyFactory as v3

### DIFF
--- a/packages/v0-core/package.json
+++ b/packages/v0-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-core",
   "description": "Framework-agnostic package that defines Lagoon related entity classes (such as Vault)",
-  "version": "0.19.15",
+  "version": "0.19.16",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/src/addresses.ts
+++ b/packages/v0-core/src/addresses.ts
@@ -122,7 +122,7 @@ export const addresses = {
     "v0_5_0": "0xC1D5F01A6491b97B94F3670Aed4BEcB897293CF8",
     wrappedNative: "0x5555555555555555555555555555555555555555",
     optinFactory: "0x90beB507A1BA7D64633540cbce615B574224CD84",
-    isOptinFactoryV3: false,
+    isOptinFactoryV3: true,
   },
   [ChainId.LineaMainnet]: {
     feeRegistry: "0xC81Dd51239119Db80D5a6E1B7347F3C3BC8674d9",


### PR DESCRIPTION
## Summary
- The HyperEVM OptinProxyFactory (`0x90beB507A1BA7D64633540cbce615B574224CD84`) is a **v3** factory, but the `addresses` map flagged it `isOptinFactoryV3: false`.
- Corrected the flag to `true` so consumers select the v3 bytes-overload `createVaultProxy(address,address,uint256,bytes,bytes32)` path on HyperEVM (consistent with the other v0.6.0 chains: Ethereum, Arbitrum, Base, Avalanche).
- Bumped `@lagoon-protocol/v0-core` `0.19.15` → `0.19.16`.

## Test plan
- [ ] CI build/typecheck passes
- [ ] Verify a v0.6.0 deploy on HyperEVM resolves the v3 factory path