### PR TITLE
feat(v0-viem): clarify pending getters, add getTotalPending{Assets,Shares}

### DIFF
--- a/packages/v0-computation/package.json
+++ b/packages/v0-computation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-computation",
   "description": "Computation package that defines some Lagoon related computations utilities",
-  "version": "0.18.7",
+  "version": "0.18.8",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/package.json
+++ b/packages/v0-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-core",
   "description": "Framework-agnostic package that defines Lagoon related entity classes (such as Vault)",
-  "version": "0.19.16",
+  "version": "0.19.17",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-viem/package.json
+++ b/packages/v0-viem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-viem",
   "description": "Viem based package that defines Lagoon utilities for vault core classes",
-  "version": "0.18.10",
+  "version": "0.18.11",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-viem/src/augment/Vault.ts
+++ b/packages/v0-viem/src/augment/Vault.ts
@@ -73,74 +73,25 @@ declare module "@lagoon-protocol/v0-core" {
      */
     getSafeBalance(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchBalanceOf>;
 
-    /**
-     * Gets share and asset balances currently held in the vault's pending silo,
-     * i.e. everything queued across all not-yet-processed settlements.
-     * This is the total pending amount — the raw silo balances.
-     * @param client - Viem client for blockchain interactions
-     * @param parameters - Optional fetch parameters (block number, state overrides, etc.) include revalidata to bypass cache
-     * @returns Promise<{shares: BigInt, assets: BigInt}> - Silo balances
-     * @see getTotalPendingAssets / getTotalPendingShares for the individual values
-     * @see getPendingSettlementAssets / getPendingSettlementShares for the next-settlement slice
-     */
+    /** Total shares and assets queued in the pending silo across all unsettled settlements. @see getTotalPendingAssets @see getPendingSettlementAssets */
     getSiloBalances(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchPendingSiloBalances>;
 
-    /**
-     * Gets the assets pending to be deposited in the NEXT settlement only.
-     * Once a valuation has been proposed this returns that settlement's slice,
-     * which excludes deposits queued afterwards — use getTotalPendingAssets for
-     * the full silo balance.
-     * @param client - Viem client for blockchain interactions
-     * @param parameters - Optional fetch parameters
-     * @returns Promise<bigint> - Next-settlement pending assets amount
-     * @see getTotalPendingAssets for everything queued in the silo
-     */
+    /** Assets pending for the NEXT settlement only (0 once a later valuation is proposed). @see getTotalPendingAssets */
     getPendingSettlementAssets(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchPendingSettlementAssets>;
 
-    /**
-     * Gets the shares pending to be redeemed in the NEXT settlement only.
-     * Once a valuation has been proposed this returns that settlement's slice,
-     * which excludes redemptions queued afterwards — use getTotalPendingShares
-     * for the full silo balance.
-     * @param client - Viem client for blockchain interactions
-     * @param parameters - Optional fetch parameters
-     * @returns Promise<bigint> - Next-settlement pending shares amount
-     * @see getTotalPendingShares for everything queued in the silo
-     */
+    /** Shares pending for the NEXT settlement only (0 once a later valuation is proposed). @see getTotalPendingShares */
     getPendingSettlementShares(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchPendingSettlementShares>;
 
-    /**
-     * Gets the total assets currently pending in the silo (all unsettled deposits).
-     * This is what you usually want to answer "how much is pending right now".
-     * @param client - Viem client for blockchain interactions
-     * @param parameters - Optional fetch parameters
-     * @returns Promise<bigint> - Silo asset balance
-     * @see getPendingSettlementAssets for the next-settlement slice only
-     */
+    /** Total assets currently in the silo (all unsettled deposits) — usually what you want. @see getPendingSettlementAssets */
     getTotalPendingAssets(client: Client, parameters?: FetchParameters): Promise<bigint>;
 
-    /**
-     * Gets the total shares currently pending in the silo (all unsettled redemptions).
-     * This is what you usually want to answer "how much is pending right now".
-     * @param client - Viem client for blockchain interactions
-     * @param parameters - Optional fetch parameters
-     * @returns Promise<bigint> - Silo share balance
-     * @see getPendingSettlementShares for the next-settlement slice only
-     */
+    /** Total shares currently in the silo (all unsettled redemptions) — usually what you want. @see getPendingSettlementShares */
     getTotalPendingShares(client: Client, parameters?: FetchParameters): Promise<bigint>;
 
-    /**
-     * @deprecated Renamed to {@link getPendingSettlementAssets} — this only returns
-     * the NEXT settlement's slice. For the full silo balance use getTotalPendingAssets.
-     * Will be removed in the next major version.
-     */
+    /** @deprecated next-settlement slice only; use {@link getPendingSettlementAssets}, or getTotalPendingAssets for the full silo balance. */
     getPendingAssets(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchPendingSettlementAssets>;
 
-    /**
-     * @deprecated Renamed to {@link getPendingSettlementShares} — this only returns
-     * the NEXT settlement's slice. For the full silo balance use getTotalPendingShares.
-     * Will be removed in the next major version.
-     */
+    /** @deprecated next-settlement slice only; use {@link getPendingSettlementShares}, or getTotalPendingShares for the full silo balance. */
     getPendingShares(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchPendingSettlementShares>;
 
     /**
@@ -241,7 +192,6 @@ Vault.prototype.getPendingSettlementShares =
     return fetchPendingSettlementShares(this, this.redeemSettleId, client, parameters)
   }
 
-// ponytail: single silo balanceOf each; use getSiloBalances() to fetch both at once.
 Vault.prototype.getTotalPendingAssets =
   async function (client: Client, parameters: FetchParameters = {}) {
     return fetchBalanceOf({ address: this.asset }, this.pendingSilo, client, parameters)
@@ -252,13 +202,11 @@ Vault.prototype.getTotalPendingShares =
     return fetchBalanceOf({ address: this.address }, this.pendingSilo, client, parameters)
   }
 
-/** @deprecated use getPendingSettlementAssets */
 Vault.prototype.getPendingAssets =
   async function (client: Client, parameters: FetchParameters = {}) {
     return fetchPendingSettlementAssets(this, this.depositSettleId, client, parameters)
   }
 
-/** @deprecated use getPendingSettlementShares */
 Vault.prototype.getPendingShares =
   async function (client: Client, parameters: FetchParameters = {}) {
     return fetchPendingSettlementShares(this, this.redeemSettleId, client, parameters)

--- a/packages/v0-viem/src/augment/Vault.ts
+++ b/packages/v0-viem/src/augment/Vault.ts
@@ -74,26 +74,72 @@ declare module "@lagoon-protocol/v0-core" {
     getSafeBalance(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchBalanceOf>;
 
     /**
-     * Gets share and asset balances in the vault's pending silo
+     * Gets share and asset balances currently held in the vault's pending silo,
+     * i.e. everything queued across all not-yet-processed settlements.
+     * This is the total pending amount — the raw silo balances.
      * @param client - Viem client for blockchain interactions
      * @param parameters - Optional fetch parameters (block number, state overrides, etc.) include revalidata to bypass cache
      * @returns Promise<{shares: BigInt, assets: BigInt}> - Silo balances
+     * @see getTotalPendingAssets / getTotalPendingShares for the individual values
+     * @see getPendingSettlementAssets / getPendingSettlementShares for the next-settlement slice
      */
     getSiloBalances(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchPendingSiloBalances>;
 
     /**
-     * Gets the pending assets to be deposited in the next settlement
+     * Gets the assets pending to be deposited in the NEXT settlement only.
+     * Once a valuation has been proposed this returns that settlement's slice,
+     * which excludes deposits queued afterwards — use getTotalPendingAssets for
+     * the full silo balance.
      * @param client - Viem client for blockchain interactions
      * @param parameters - Optional fetch parameters
-     * @returns Promise<bigint> - Pending assets amount
+     * @returns Promise<bigint> - Next-settlement pending assets amount
+     * @see getTotalPendingAssets for everything queued in the silo
+     */
+    getPendingSettlementAssets(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchPendingSettlementAssets>;
+
+    /**
+     * Gets the shares pending to be redeemed in the NEXT settlement only.
+     * Once a valuation has been proposed this returns that settlement's slice,
+     * which excludes redemptions queued afterwards — use getTotalPendingShares
+     * for the full silo balance.
+     * @param client - Viem client for blockchain interactions
+     * @param parameters - Optional fetch parameters
+     * @returns Promise<bigint> - Next-settlement pending shares amount
+     * @see getTotalPendingShares for everything queued in the silo
+     */
+    getPendingSettlementShares(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchPendingSettlementShares>;
+
+    /**
+     * Gets the total assets currently pending in the silo (all unsettled deposits).
+     * This is what you usually want to answer "how much is pending right now".
+     * @param client - Viem client for blockchain interactions
+     * @param parameters - Optional fetch parameters
+     * @returns Promise<bigint> - Silo asset balance
+     * @see getPendingSettlementAssets for the next-settlement slice only
+     */
+    getTotalPendingAssets(client: Client, parameters?: FetchParameters): Promise<bigint>;
+
+    /**
+     * Gets the total shares currently pending in the silo (all unsettled redemptions).
+     * This is what you usually want to answer "how much is pending right now".
+     * @param client - Viem client for blockchain interactions
+     * @param parameters - Optional fetch parameters
+     * @returns Promise<bigint> - Silo share balance
+     * @see getPendingSettlementShares for the next-settlement slice only
+     */
+    getTotalPendingShares(client: Client, parameters?: FetchParameters): Promise<bigint>;
+
+    /**
+     * @deprecated Renamed to {@link getPendingSettlementAssets} — this only returns
+     * the NEXT settlement's slice. For the full silo balance use getTotalPendingAssets.
+     * Will be removed in the next major version.
      */
     getPendingAssets(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchPendingSettlementAssets>;
 
     /**
-     * Gets the pending shares to be redeemed in the next settlement
-     * @param client - Viem client for blockchain interactions
-     * @param parameters - Optional fetch parameters
-     * @returns Promise<bigint> - Pending shares amount
+     * @deprecated Renamed to {@link getPendingSettlementShares} — this only returns
+     * the NEXT settlement's slice. For the full silo balance use getTotalPendingShares.
+     * Will be removed in the next major version.
      */
     getPendingShares(client: Client, parameters?: FetchParameters): ReturnType<typeof fetchPendingSettlementShares>;
 
@@ -185,11 +231,34 @@ Vault.prototype.getSiloBalances =
     return fetchPendingSiloBalances(this, client, parameters)
   }
 
+Vault.prototype.getPendingSettlementAssets =
+  async function (client: Client, parameters: FetchParameters = {}) {
+    return fetchPendingSettlementAssets(this, this.depositSettleId, client, parameters)
+  }
+
+Vault.prototype.getPendingSettlementShares =
+  async function (client: Client, parameters: FetchParameters = {}) {
+    return fetchPendingSettlementShares(this, this.redeemSettleId, client, parameters)
+  }
+
+// ponytail: single silo balanceOf each; use getSiloBalances() to fetch both at once.
+Vault.prototype.getTotalPendingAssets =
+  async function (client: Client, parameters: FetchParameters = {}) {
+    return fetchBalanceOf({ address: this.asset }, this.pendingSilo, client, parameters)
+  }
+
+Vault.prototype.getTotalPendingShares =
+  async function (client: Client, parameters: FetchParameters = {}) {
+    return fetchBalanceOf({ address: this.address }, this.pendingSilo, client, parameters)
+  }
+
+/** @deprecated use getPendingSettlementAssets */
 Vault.prototype.getPendingAssets =
   async function (client: Client, parameters: FetchParameters = {}) {
     return fetchPendingSettlementAssets(this, this.depositSettleId, client, parameters)
   }
 
+/** @deprecated use getPendingSettlementShares */
 Vault.prototype.getPendingShares =
   async function (client: Client, parameters: FetchParameters = {}) {
     return fetchPendingSettlementShares(this, this.redeemSettleId, client, parameters)

--- a/packages/v0-viem/test/Vault.test.ts
+++ b/packages/v0-viem/test/Vault.test.ts
@@ -191,6 +191,19 @@ describe("augment/Vault", () => {
     expect(value).toStrictEqual(expectedValue);
   });
 
+  test2("getPendingSettlementAssets/Shares match the deprecated aliases", async ({ client }) => {
+    const flagship9sEth = await Vault.fetch("0x07ed467acd4ffd13023046968b0859781cb90d9b", client);
+    expect(await flagship9sEth?.getPendingSettlementAssets(client)).toStrictEqual(await flagship9sEth?.getPendingAssets(client));
+    expect(await flagship9sEth?.getPendingSettlementShares(client)).toStrictEqual(await flagship9sEth?.getPendingShares(client));
+  });
+
+  test.sequential("getTotalPending{Assets,Shares} equal the silo balances", async ({ client }) => {
+    const flagship9sEth = await Vault.fetch("0x07ed467acd4ffd13023046968b0859781cb90d9b", client);
+    const silo = await flagship9sEth?.getSiloBalances(client);
+    expect(await flagship9sEth?.getTotalPendingAssets(client)).toStrictEqual(silo?.assets);
+    expect(await flagship9sEth?.getTotalPendingShares(client)).toStrictEqual(silo?.shares);
+  });
+
   test2("should fetch 0 assets to unwind", async ({ client }) => {
     const expectedValue = {
       assetsToUnwind: 0n,


### PR DESCRIPTION
## Problem

`Vault.getPendingAssets()` / `getPendingShares()` are misleadingly named. They return the amount pending **for the next settlement's `settleId`** — not the total sitting in the pending silo. Once a valuation is proposed they fall back to `settleData.pendingAssets` (0 for the next settle) even though fresh deposits are queued in the silo for a future settlement.

Reported case: vault `0xe6b30da13c2c97aacd8ba3df4e97977725847fca` (HyperEVM) with a 100 USDC pending deposit — the silo ERC20 balance reads `100e6`, but `getPendingAssets()` returns `0n`. Not a bug: `getSiloBalances()` already returns the raw silo `{shares, assets}`, but the naming led users to the wrong getter.

## Changes

All in `packages/v0-viem/src/augment/Vault.ts` (instance-method layer only — the backing `fetch` fns were already named `fetchPendingSettlement*`):

- **`getPendingSettlementAssets()` / `getPendingSettlementShares()`** — clearer names for the existing next-settlement behavior.
- **`getTotalPendingAssets()` / `getTotalPendingShares()`** — full silo balance (single `balanceOf` each). This is the value users usually want.
- **`getPendingAssets()` / `getPendingShares()`** — kept as `@deprecated` forwarding aliases; no behavior change, removed next major.
- JSDoc on all getters + `getSiloBalances` now cross-reference the settlement-slice vs total-pending distinction.

## Tests

Added in `packages/v0-viem/test/Vault.test.ts`:
- `getPendingSettlement*` equal the deprecated aliases (wiring guard).
- `getTotalPending{Assets,Shares}` equal `getSiloBalances()` (divergent-case vault `0x07ed…`: silo `2e14` vs settlement `26.21e18`).

Fork tests require `MAINNET_RPC_URL`; run `MAINNET_RPC_URL=<url> bun run test` in `packages/v0-viem` to execute them. `bun run build` (incl. type-gen) is green.

Patch version bump across all three packages.