### PR TITLE
feat: register Flare mainnet (chain 14)

### DIFF
--- a/packages/v0-computation/package.json
+++ b/packages/v0-computation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-computation",
   "description": "Computation package that defines some Lagoon related computations utilities",
-  "version": "0.18.8",
+  "version": "0.18.9",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/package.json
+++ b/packages/v0-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-core",
   "description": "Framework-agnostic package that defines Lagoon related entity classes (such as Vault)",
-  "version": "0.19.17",
+  "version": "0.19.18",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/packages/v0-core/src/addresses.ts
+++ b/packages/v0-core/src/addresses.ts
@@ -184,5 +184,12 @@ export const addresses = {
     wrappedNative: "0x0000000000000000000000000000000000000400",
     optinFactory: "0xfA032DE1214fD89b465c306BF46F778318bDe357",
     isOptinFactoryV3: true,
+  },
+  [ChainId.FlareMainnet]: {
+    feeRegistry: "0x2dFc451aB2a4b9c95E68B480fbC2C759BaE68887",
+    "v0_6_0": "0x46940275d230fd2bb734fd1ced451b260b3bd7f8",
+    wrappedNative: "0x1D80c49BbBCd1C0911346656B529DF9E5c2F783d",
+    optinFactory: "0x70274C69Ef1fA492506394D982391c6f3008e785",
+    isOptinFactoryV3: true,
   }
 } as const satisfies Record<ChainId, unknown>;

--- a/packages/v0-core/src/chain.ts
+++ b/packages/v0-core/src/chain.ts
@@ -20,6 +20,7 @@ export enum ChainId {
   SeiMainnet = 1329,
   HemiMainnet = 43111,
   RaylsMainnet = 72957,
+  FlareMainnet = 14,
 }
 
 export interface ChainMetadata {
@@ -198,6 +199,13 @@ export namespace ChainUtils {
       nativeCurrency: { name: "USD Rayls", symbol: "USDr", decimals: 18 },
       explorerUrl: "https://explorer.rayls.com",
       identifier: "rayls",
+    },
+    [ChainId.FlareMainnet]: {
+      name: "Flare",
+      id: ChainId.FlareMainnet,
+      nativeCurrency: { name: "Flare", symbol: "FLR", decimals: 18 },
+      explorerUrl: "https://flare-explorer.flare.network",
+      identifier: "flare",
     }
   } as const
 }

--- a/packages/v0-viem/package.json
+++ b/packages/v0-viem/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lagoon-protocol/v0-viem",
   "description": "Viem based package that defines Lagoon utilities for vault core classes",
-  "version": "0.18.11",
+  "version": "0.18.12",
   "license": "MIT",
   "type": "module",
   "main": "./dist/cjs/index.cjs",


### PR DESCRIPTION
Adds Flare mainnet (chain 14) to the SDK.

- `ChainId.FlareMainnet` + metadata (FLR, `https://flare-explorer.flare.network`, identifier `flare`)
- Deployment addresses: feeRegistry, v0.6.0 vault logic, WFLR, v3 optinFactory

Flare is v0.6.0 only — no earlier vault logic deployed.

Packages bumped: core 0.19.18, viem 0.18.12, computation 0.18.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)